### PR TITLE
Enable asserts, add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,4 +67,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/gui/DialogueBox.java
+++ b/src/main/java/gui/DialogueBox.java
@@ -28,10 +28,13 @@ public class DialogueBox extends HBox {
     private final Image image; // Separate out initialize() method for better structuring.
 
     private DialogueBox(String newDialogue, Image newImage) {
+        assert newDialogue != null : "newDialogue text cannot be null";
         this.dialogueString = newDialogue;
+        assert newImage != null : "Image cannot be null";
         this.image = newImage;
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/DialogueBox.fxml"));
+            assert fxmlLoader.getLocation() != null : "DialogueBox.fxml absent in ../resources/view/DialogueBox.fxml";
             fxmlLoader.setController(this);
             fxmlLoader.setRoot(this);
             fxmlLoader.load();

--- a/src/main/java/steadylah/task/TaskList.java
+++ b/src/main/java/steadylah/task/TaskList.java
@@ -49,6 +49,7 @@ public class TaskList {
      * @param task New task.
      */
     public String addTask(Task task) {
+        assert task != null : "Task cannot be null for meaningful task insertion.";
         StringBuilder addResponse = new StringBuilder();
         addResponse.append("Got it. I've added this task:\n");
         this.taskLogs.add(task);

--- a/text-ui-test/runtest.bat
+++ b/text-ui-test/runtest.bat
@@ -18,7 +18,7 @@ REM no error here, ERRORLEVEL == 0
 
 REM run the program, feed commands from input.txt file and redirect the output to the ACTUAL.TXT
 REM Main file modified from Duke.java to SteadyLah.java, hence the name change below
-java -classpath ..\bin steadylah.SteadyLah < input.txt > ACTUAL.TXT
+java -ea -classpath ..\bin steadylah.SteadyLah < input.txt > ACTUAL.TXT
 
 REM compare the output to the expected output
 FC ACTUAL.TXT EXPECTED.TXT


### PR DESCRIPTION
- Add assertions to enforce non-null constraints in `DialogueBox` and `TaskList`  
- Modify `runtest.bat` to enable assertions (`-ea` flag) for test execution  
- Ensure `FXMLLoader` resource location is validated before loading